### PR TITLE
Fix issue with inaccessible background tabs

### DIFF
--- a/vimari.safariextension/global.html
+++ b/vimari.safariextension/global.html
@@ -20,10 +20,21 @@
 			}
 		}
 
-
+		// Dispatch a message to a tab's page or reader view
+		function dispatchMessage(target, name, message) {
+		  if (target) {
+		    // Do some checks on the target to make sure we aren't trying to send a
+		    // message to inaccessible tabs (e.g. Top Sites)
+		    if (target.page && typeof target.page.dispatchMessage === "function") {
+		      target.page.dispatchMessage(name, message);
+		    } else if (typeof target.dispatchMessage === "function") {
+		      target.dispatchMessage(name, message);
+		    }
+		  }
+		}
 
 		// Pass the settings on to the injected script
-   		function getSettings() {
+   		function getSettings(event) {
 			var settings = {
 				'linkHintCharacters' : safari.extension.settings.linkHintCharacters,
 				'hintToggle'         : safari.extension.settings.hintToggle,
@@ -49,7 +60,7 @@
 				'detectByCursorStyle': safari.extension.settings.detectByCursorStyle
 			};
 
-			safari.application.activeBrowserWindow.tabs[getActiveTab()].page.dispatchMessage('setSettings', settings);
+			dispatchMessage(event.target, 'setSettings', settings);
 
 		}
 
@@ -119,12 +130,12 @@
 			i;
 
 		for (i=0;i<tabs.length;i++) {
-			safari.application.activeBrowserWindow.tabs[i].page.dispatchMessage('setActive', false);
+			dispatchMessage(safari.application.activeBrowserWindow.tabs[i], 'setActive', false);
 		}
 
 		for (i=0;i<tabs.length;i++) {
 			if (tabs[i] === safari.application.activeBrowserWindow.activeTab) {
-				safari.application.activeBrowserWindow.tabs[i].page.dispatchMessage('setActive', true);
+				dispatchMessage(safari.application.activeBrowserWindow.tabs[i], 'setActive', true);
 			}
 		}
 
@@ -137,7 +148,7 @@
 	// Need to detect if a new tab becomes active and if so, reload the extension
 	safari.application.addEventListener('activate', function(event) {
 			activateTab();
-			getSettings();
+			getSettings(event);
 		}, true);
 
 


### PR DESCRIPTION
I replaced all calls to page.dispatchMessage with a new dispatchMessage function. This function checks to make sure the extension has permission to access the tab before trying to dispatch a message to it, which prevents Favorites/Top Sites or file:// pages from breaking vimari. Additionally, this lets us dispatch messages to a tab's Reader view, opening up the possibility of having vimari run in Reader (I'll open up a separate issue with details on how to get Reader support working).

Fixes #47 