### PR TITLE
Fix link hints on pages with SVG

### DIFF
--- a/vimari.safariextension/linkHints.js
+++ b/vimari.safariextension/linkHints.js
@@ -164,11 +164,16 @@ function getFirstVisibleRect(element) {
       return {element: element, rect: clientRect};
     }
   }
-  // find visible clientRect of child
-  for (var j = 0; j < element.children.length; j++) {
-    var childClientRect = getFirstVisibleRect(element.children[j]);
-    if (childClientRect) {
-      return childClientRect;
+  // Only iterate over elements with a children property. This is mainly to
+  // avoid issues with SVG elements, as Safari doesn't expose a children
+  // property on them.
+  if (element.children) {
+    // find visible clientRect of child
+    for (var j = 0; j < element.children.length; j++) {
+      var childClientRect = getFirstVisibleRect(element.children[j]);
+      if (childClientRect) {
+        return childClientRect;
+      }
     }
   }
   return null;


### PR DESCRIPTION
Link hints currently doesn't work with pages that have SVG elements, such as <http://www.theverge.com>. I looked in to it, and it appears Safari doesn't expose a children property on SVG elements (see the [Browser Compatibility] table on MDN). To fix this, I've added a check to make sure we don't try to iterate over elements missing a children property.

[Browser Compatibility]: https://developer.mozilla.org/en-US/docs/Web/API/ParentNode.children#Browser_compatibility