### PR TITLE
Default to no command prefix.

### DIFF
--- a/vimari.safariextension/Settings.plist
+++ b/vimari.safariextension/Settings.plist
@@ -10,7 +10,7 @@
 	</dict>
 	<dict>
 		<key>DefaultValue</key>
-		<string>ctrl</string>
+		<string></string>
 		<key>Key</key>
 		<string>modifier</string>
 		<key>Title</key>


### PR DESCRIPTION
I agree with @gjcourt's [comment](https://github.com/guyht/vimari/issues/60#issuecomment-133504781) in #60 that having `ctrl` as the default command prefix made me think this was buggy. This removes it.
