### PR TITLE
Use non-deprecated function to click links

### DIFF
--- a/vimari.safariextension/linkHints.js
+++ b/vimari.safariextension/linkHints.js
@@ -350,31 +350,7 @@ function numberToHintString(number, numHintDigits) {
 }
 
 function simulateClick(link) {
-  // Configure events with appropriate meta key (CMD on Mac, CTRL on windows) 
-  // to open links in new tabs if necessary.
-  var metaKey = (platform === "Mac" && shouldOpenLinkHintInNewTab);
-  var ctrlKey = (platform !== "Mac" && shouldOpenLinkHintInNewTab);
-
-  // A full click will be simulated by the sequence:
-  // focus --> mouseDown --> mouseUp --> click
-  // The focus step is there because Safari has been observed to do so.
-
-  link.focus();
-
-  var mouseDownEvent = document.createEvent("MouseEvents");
-  mouseDownEvent.initMouseEvent("mousedown", true, true, window, 1, 0, 0, 0, 0, ctrlKey, false, false, metaKey, 0, null);
-  link.dispatchEvent(mouseDownEvent)
-
-  var mouseUpEvent = document.createEvent("MouseEvents");
-  mouseUpEvent.initMouseEvent("mouseup", true, true, window, 1, 0, 0, 0, 0, ctrlKey, false, false, metaKey, 0, null);
-  link.dispatchEvent(mouseUpEvent);
-
-  var clickEvent = document.createEvent("MouseEvents");
-  clickEvent.initMouseEvent("click", true, true, window, 1, 0, 0, 0, 0, ctrlKey, false, false, metaKey, 0, null);
-  link.dispatchEvent(clickEvent);
-
-  // On click event dispatch, Firefox will not execute the link's default action, but Webkit will. 
-  // This is a Safari extension, so that's ok for now, if no easy cross-browser solution is available.
+  link.click();
 }
 
 function deactivateLinkHintsMode() {


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click
the .link() function is supported by Safari 6 and up.